### PR TITLE
Add package selection to update workflow

### DIFF
--- a/.github/workflows/update-icons.yml
+++ b/.github/workflows/update-icons.yml
@@ -2,12 +2,23 @@ name: Update Icon Packages
 
 on:
   workflow_dispatch:
+    inputs:
+      package:
+        description: 'Which package to update?'
+        required: true
+        type: choice
+        options:
+          - icons-material
+          - icons-ant
+          - all
+        default: icons-material
 
 permissions:
   contents: write
 
 jobs:
   update:
+    if: ${{ github.event.inputs.package == 'all' || github.event.inputs.package == matrix.pkg.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- enhance `update-icons` workflow with input parameter to choose package
- skip matrix jobs based on the selected input

## Testing
- `node -v`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68849cf99a30832b8850ce7019425e28